### PR TITLE
Blinky interrupt rtt

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,8 @@ cortex-m-rt = "0.6.12"
 cortex-m-semihosting = "~0.3"
 panic-semihosting = "~0.5"
 nb = "~0.1"
+panic-rtt-target = { version = "0.1", features = ["cortex-m"] }
+rtt-target = { version = "0.2", features = ["cortex-m"] }
 
 [features]
 rt = ["nrf52840-hal/rt"]

--- a/Embed.toml
+++ b/Embed.toml
@@ -1,0 +1,46 @@
+[probe]
+# The index of the probe in the connected probe list.
+#probe_selector = "1366:1015"
+# The protocol to be used for communicating with the target.
+protocol = "Swd"
+# The speed in kHz of the data link to the target.
+speed = 1000
+
+[flashing]
+# Whether or not the target should be flashed.
+enabled = true
+# Whether or not the target should be halted after flashing.
+halt_afterwards = false
+# Whether or not bytes erased but not rewritten with data from the ELF
+# should be restored with their contents before erasing.
+restore_unwritten_bytes = false
+# The path where an SVG of the assembled flash layout should be written to.
+# flash_layout_output_path = "out.svg"
+
+[general]
+# The chip name of the chip to be debugged.
+chip = "nrf52840_xxaa"
+# A list of chip descriptions to be loaded during runtime.
+chip_descriptions = []
+# The default log level to be used.
+log_level = "Warn"
+
+[rtt]
+# Whether or not an RTTUI should be opened after flashing.
+# This is exclusive and cannot be used with GDB at the moment.
+enabled = true
+# A list of channel associations to be displayed. If left empty, all channels are displayed.
+channels = [
+    # { up = 0, down = 0, name = "name" }
+]
+# The duration in ms for which the logger should retry to attach to RTT.
+timeout = 3000
+# Whether timestamps in the RTTUI are enabled
+show_timestamps = true
+
+[gdb]
+# Whether or not a GDB server should be opened after flashing.
+# This is exclusive and cannot be used with RTT at the moment.
+enabled = false
+# The connection string in host:port format wher the GDB server will open a socket.
+# gdb_connection_string

--- a/examples/blinky_interrupt_rtt.rs
+++ b/examples/blinky_interrupt_rtt.rs
@@ -1,0 +1,138 @@
+#![no_main]
+#![no_std]
+
+//! Blinks LED1 every second and lights up LED 2 when button 2 is pressed.
+//! Prints messages over RTT
+
+use core::cell::RefCell;
+use core::ops::DerefMut;
+use cortex_m::interrupt::{free, Mutex};
+use embedded_hal::timer::CountDown;
+
+use cortex_m_rt::entry;
+
+use panic_rtt_target as _;
+
+use rtt_target::{rprintln, rtt_init_print};
+
+use bsp::hal;
+use hal::target as pac;
+use nrf52840_dk_bsp as bsp;
+
+use pac::interrupt;
+
+/// A struct used to hold the resources we need
+struct Blinky {
+    /// Timer 0
+    timer0: hal::Timer<pac::TIMER0, hal::timer::Periodic>,
+    /// Timer 1
+    timer1: hal::Timer<pac::TIMER1, hal::timer::Periodic>,
+    /// LED 1
+    led1: bsp::Led,
+    /// LED 2
+    led2: bsp::Led,
+    /// button 2
+    button2: bsp::Button,
+    /// LED 1 state
+    led1_on: bool,
+}
+
+/// Program resources
+static BLINKY: Mutex<RefCell<Option<Blinky>>> = Mutex::new(RefCell::new(None));
+
+#[entry]
+fn main() -> ! {
+    // Enable RTT printing
+    rtt_init_print!();
+    // Print a message over RTT
+    rprintln!("Initialize");
+    rprintln!("Press button 2 to light up LED 2");
+    // Configure the board perephials
+    if let Some(nrf52) = bsp::Board::take() {
+        // Configure the timer TIMER0 to fire every second
+        let mut timer0 = hal::Timer::new(nrf52.TIMER0);
+        timer0.enable_interrupt();
+        let mut timer0 = timer0.into_periodic();
+        timer0.start(1_000_000u32);
+        // Configure the timer TIMER1 to fire 50 milliseconds
+        let mut timer1 = hal::Timer::new(nrf52.TIMER1);
+        timer1.enable_interrupt();
+        let mut timer1 = timer1.into_periodic();
+        timer1.start(50_000u32);
+        // Get LED 1 and turn it off
+        let mut led1 = nrf52.leds.led_1;
+        led1.disable();
+        // Get LED 2 and turn it off
+        let mut led2 = nrf52.leds.led_2;
+        led2.disable();
+        // Remove any pending interrupts on TIMER0 and TIMER1
+        pac::NVIC::unpend(pac::Interrupt::TIMER0);
+        pac::NVIC::unpend(pac::Interrupt::TIMER1);
+        // Enable interrupts
+        unsafe {
+            pac::NVIC::unmask(pac::Interrupt::TIMER0);
+            pac::NVIC::unmask(pac::Interrupt::TIMER1);
+        }
+        // Create Blinky struct
+        let blinky = Blinky {
+            timer0,
+            timer1,
+            led1,
+            led2,
+            button2: nrf52.buttons.button_2,
+            led1_on: false,
+        };
+        // Store the Blinky struct in the static variable
+        free(|cs| {
+            BLINKY.borrow(cs).replace(Some(blinky));
+        });
+    }
+    // Loop endlessly
+    loop {}
+}
+
+#[interrupt]
+fn TIMER0() {
+    // Lock the Mutex to borrow the resources
+    free(|cs| {
+        if let Some(ref mut blinky) = BLINKY.borrow(cs).borrow_mut().deref_mut() {
+            // Wait and reset the timer event
+            let _ = blinky.timer0.wait();
+            // Check the state variable
+            if blinky.led1_on {
+                // Enable LED 1
+                blinky.led1.enable();
+            } else {
+                // Disable LED 1
+                blinky.led1.disable();
+            }
+            // Update the state variable
+            blinky.led1_on = !blinky.led1_on;
+        }
+    });
+    // Print a message over RTT
+    rprintln!("TIMER0");
+    // Clear the interrupt
+    pac::NVIC::unpend(pac::Interrupt::TIMER0);
+}
+
+#[interrupt]
+fn TIMER1() {
+    // Lock the Mutex to borrow the resources
+    free(|cs| {
+        if let Some(ref mut blinky) = BLINKY.borrow(cs).borrow_mut().deref_mut() {
+            // Wait and reset the timer event
+            let _ = blinky.timer1.wait();
+            // Check if the button is pressed
+            if blinky.button2.is_pressed() {
+                // Enable LED 2
+                blinky.led2.enable();
+            } else {
+                // Disable LED 2
+                blinky.led2.disable();
+            }
+        }
+    });
+    // Clear the interrupt
+    pac::NVIC::unpend(pac::Interrupt::TIMER1);
+}

--- a/examples/blinky_interrupt_rtt.rs
+++ b/examples/blinky_interrupt_rtt.rs
@@ -65,9 +65,9 @@ fn main() -> ! {
         // Get LED 2 and turn it off
         let mut led2 = nrf52.leds.led_2;
         led2.disable();
-        // Remove any pending interrupts on TIMER0 and TIMER1
-        pac::NVIC::unpend(pac::Interrupt::TIMER0);
-        pac::NVIC::unpend(pac::Interrupt::TIMER1);
+        // Clear timer events
+        let _ = timer0.wait();
+        let _ = timer1.wait();
         // Enable interrupts
         unsafe {
             pac::NVIC::unmask(pac::Interrupt::TIMER0);
@@ -112,8 +112,6 @@ fn TIMER0() {
     });
     // Print a message over RTT
     rprintln!("TIMER0");
-    // Clear the interrupt
-    pac::NVIC::unpend(pac::Interrupt::TIMER0);
 }
 
 #[interrupt]
@@ -133,6 +131,4 @@ fn TIMER1() {
             }
         }
     });
-    // Clear the interrupt
-    pac::NVIC::unpend(pac::Interrupt::TIMER1);
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,7 +24,7 @@ use nrf52840_hal::{
     uarte::{self, Baudrate as UartBaudrate, Parity as UartParity, Uarte},
 };
 
-use embedded_hal::digital::v2::OutputPin;
+use embedded_hal::digital::v2::{InputPin, OutputPin};
 
 /// Provides access to all features of the nRF52840-DK board
 #[allow(non_snake_case)]
@@ -541,6 +541,16 @@ pub struct Button(Pin<Input<PullUp>>);
 impl Button {
     fn new<Mode>(pin: Pin<Mode>) -> Self {
         Button(pin.into_pullup_input())
+    }
+
+    /// Button is pressed
+    pub fn is_pressed(&self) -> bool {
+        self.0.is_low().unwrap()
+    }
+
+    /// Button is released
+    pub fn is_released(&self) -> bool {
+        self.0.is_high().unwrap()
     }
 }
 


### PR DESCRIPTION
Add a example that shows off LEDs, Buttons, RTT and cargo embed.

It was a while since I last wrote non-RTIC interrupt handling so please take care to check if that seems sane.

Also, I was not able to get the probe_selector to work with the embedded JLink on nRF52840-DK.
