### PR TITLE
Fix docs link

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ To use in your own application, add as a dependency and call the
 
 ## Documentation
 
-The docs for this crate can be found at https://docs.rs/crate/nrf52840-dk-bsp. The
+The docs for this crate can be found at https://docs.rs/nrf52840-dk-bsp. The
 manufacturer's documentation is available from
 https://infocenter.nordicsemi.com/pdf/nRF52840_DK_User_Guide_v1.4.1.pdf.
 

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ To use in your own application, add as a dependency and call the
 
 ## Documentation
 
-The docs for this crate can be found at https://docs.rs/nrf52840-DK. The
+The docs for this crate can be found at https://docs.rs/crate/nrf52840-dk-bsp. The
 manufacturer's documentation is available from
 https://infocenter.nordicsemi.com/pdf/nRF52840_DK_User_Guide_v1.4.1.pdf.
 


### PR DESCRIPTION
## Background 

Simple change to fix the link to the new crate's docs. Thank you for all the great work.

This PR is related to Issue https://github.com/nrf-rs/nRF52840-DK/issues/6