### PR TITLE
Updated nrf-hal

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ edition = "2018"
 cortex-m = { version = "0.5.4", features = [ "const-fn" ] }
 cortex-m-rt = "0.6.12"
 embedded-hal = "0.2.3"
-nrf52840-hal = "0.10.0"
+nrf52840-hal = { git = "https://github.com/nrf-rs/nrf-hal" }
 
 [dev-dependencies]
 cortex-m-rt = "0.6.12"

--- a/examples/blinky.rs
+++ b/examples/blinky.rs
@@ -1,39 +1,44 @@
-#![no_main]
 #![no_std]
+#![no_main]
 
-use cortex_m_rt::entry;
+//! This example is for the nRF52840-DK board. It prints to the UART and blinks
+//! an LED. Open the lowest-numbered USB Serial Port presented by your
+//! nRF52840-DK to see the UART output.
+
+use cortex_m_rt as rt;
+use nrf52840_dk_bsp as bsp;
+
+use bsp::{hal::Timer, prelude::*, Board};
+use core::fmt::Write;
 use nb::block;
+use rt::entry;
 
-#[allow(unused_imports)]
-use panic_semihosting;
-
-use nrf52840_dk_bsp::{
-    hal::{
-        prelude::*,
-        timer::{self, Timer},
-    },
-    Board,
-};
-
-#[entry]
-fn main() -> ! {
-    let mut nrf52 = Board::take().unwrap();
-
-    let mut timer = Timer::new(nrf52.TIMER0);
-
-    // Alternately flash the red and blue leds
+/// What to do if we get a panic!()
+#[panic_handler]
+fn panic(_: &core::panic::PanicInfo) -> ! {
     loop {
-        nrf52.leds.led_2.enable();
-        delay(&mut timer, 250_000); // 250ms
-        nrf52.leds.led_2.disable();
-        delay(&mut timer, 1_000_000); // 1s
+        cortex_m::asm::bkpt();
     }
 }
 
-fn delay<T>(timer: &mut Timer<T>, cycles: u32)
-where
-    T: timer::Instance,
-{
-    timer.start(cycles);
-    let _ = block!(timer.wait());
+#[entry]
+fn main() -> ! {
+    let mut board = Board::take().unwrap();
+    let mut timer = Timer::new(board.TIMER0);
+
+    write!(board.cdc, "Hello, world!\r\n").unwrap();
+
+    let mut led_is_on = false;
+    loop {
+        if led_is_on {
+            write!(board.cdc, "Off\r\n").unwrap();
+            board.leds.led_1.disable();
+        } else {
+            write!(board.cdc, "On\r\n").unwrap();
+            board.leds.led_1.enable();
+        }
+        timer.start(1_000_000_u32);
+        block!(timer.wait()).unwrap();
+        led_is_on = !led_is_on;
+    }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,7 +18,7 @@ pub mod prelude {
 // pub mod debug;
 
 use nrf52840_hal::{
-    gpio::{p0, p1, Floating, Input, Level, Output, Pin, PullUp, PushPull},
+    gpio::{p0, p1, Disconnected, Input, Level, Output, Pin, PullUp, PushPull},
     pac::{self as nrf52, CorePeripherals, Peripherals},
     spim::{self, Frequency, Spim, MODE_0},
     uarte::{self, Baudrate as UartBaudrate, Parity as UartParity, Uarte},
@@ -457,33 +457,33 @@ impl Board {
 /// The nRF52 pins that are available on the nRF52840DK
 #[allow(non_snake_case)]
 pub struct Pins {
-    pub P0_03: p0::P0_03<Input<Floating>>,
-    pub P0_04: p0::P0_04<Input<Floating>>,
-    _RESET: p0::P0_18<Input<Floating>>,
-    pub P0_22: p0::P0_22<Input<Floating>>,
-    pub P0_23: p0::P0_23<Input<Floating>>,
-    pub P0_26: p0::P0_26<Input<Floating>>,
-    pub P0_27: p0::P0_27<Input<Floating>>,
-    pub P0_28: p0::P0_28<Input<Floating>>,
-    pub P0_29: p0::P0_29<Input<Floating>>,
-    pub P0_30: p0::P0_30<Input<Floating>>,
-    pub P0_31: p0::P0_31<Input<Floating>>,
-    pub P1_00: p1::P1_00<Input<Floating>>,
-    pub P1_01: p1::P1_01<Input<Floating>>,
-    pub P1_02: p1::P1_02<Input<Floating>>,
-    pub P1_03: p1::P1_03<Input<Floating>>,
-    pub P1_04: p1::P1_04<Input<Floating>>,
-    pub P1_05: p1::P1_05<Input<Floating>>,
-    pub P1_06: p1::P1_06<Input<Floating>>,
-    pub P1_07: p1::P1_07<Input<Floating>>,
-    pub P1_08: p1::P1_08<Input<Floating>>,
-    pub P1_09: p1::P1_09<Input<Floating>>,
-    pub P1_10: p1::P1_10<Input<Floating>>,
-    pub P1_11: p1::P1_11<Input<Floating>>,
-    pub P1_12: p1::P1_12<Input<Floating>>,
-    pub P1_13: p1::P1_13<Input<Floating>>,
-    pub P1_14: p1::P1_14<Input<Floating>>,
-    pub P1_15: p1::P1_15<Input<Floating>>,
+    pub P0_03: p0::P0_03<Disconnected>,
+    pub P0_04: p0::P0_04<Disconnected>,
+    _RESET: p0::P0_18<Disconnected>,
+    pub P0_22: p0::P0_22<Disconnected>,
+    pub P0_23: p0::P0_23<Disconnected>,
+    pub P0_26: p0::P0_26<Disconnected>,
+    pub P0_27: p0::P0_27<Disconnected>,
+    pub P0_28: p0::P0_28<Disconnected>,
+    pub P0_29: p0::P0_29<Disconnected>,
+    pub P0_30: p0::P0_30<Disconnected>,
+    pub P0_31: p0::P0_31<Disconnected>,
+    pub P1_00: p1::P1_00<Disconnected>,
+    pub P1_01: p1::P1_01<Disconnected>,
+    pub P1_02: p1::P1_02<Disconnected>,
+    pub P1_03: p1::P1_03<Disconnected>,
+    pub P1_04: p1::P1_04<Disconnected>,
+    pub P1_05: p1::P1_05<Disconnected>,
+    pub P1_06: p1::P1_06<Disconnected>,
+    pub P1_07: p1::P1_07<Disconnected>,
+    pub P1_08: p1::P1_08<Disconnected>,
+    pub P1_09: p1::P1_09<Disconnected>,
+    pub P1_10: p1::P1_10<Disconnected>,
+    pub P1_11: p1::P1_11<Disconnected>,
+    pub P1_12: p1::P1_12<Disconnected>,
+    pub P1_13: p1::P1_13<Disconnected>,
+    pub P1_14: p1::P1_14<Disconnected>,
+    pub P1_15: p1::P1_15<Disconnected>,
 }
 
 /// The LEDs on the nRF52840-DK board
@@ -557,8 +557,8 @@ impl Button {
 /// The NFC pins on the nRF52840-DK board
 pub struct NFC {
     /// nRF52840-DK: NFC1, nRF52: P0.09
-    pub nfc_1: p0::P0_09<Input<Floating>>,
+    pub nfc_1: p0::P0_09<Disconnected>,
 
     /// nRF52840-DK: NFC2, nRF52: P0.10
-    pub nfc_2: p0::P0_10<Input<Floating>>,
+    pub nfc_2: p0::P0_10<Disconnected>,
 }


### PR DESCRIPTION
Also, a blinky example that exercises the UART given recent changes there with nrf-hal. The example is consistent with the nRF9160-dk bsp project.

One bit of weirdness that I notice is that the program blocks if there is no terminal consuming the UART output. I'm wondering if there is something peculiar re. my environment, so it someone should also check it out. Once flashed, connect to the UART and then reset the device. Prior to reset the blinky should be doing its thing. After resetting, it seems to hang/block.

Lastly, the dependency on the nrf-hal is changed to leverage master. We could probably merge this commit, but withhold a release until nrf-hal is once again released.