### PR TITLE
Update dependencies and minor fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
-
-(no changes)
-
+### Changed
+- Update dependencies
+- Remove cortex-m-rt from main dependencies
 
 [Unreleased]: https://github.com/nrf-rs/nrf52840-dk/compare/v0.1.0...HEAD

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,18 +9,16 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-cortex-m = { version = "0.5.4", features = [ "const-fn" ] }
-cortex-m-rt = "0.6.12"
-embedded-hal = "0.2.3"
-nrf52840-hal = "0.10.0"
+cortex-m = "0.7"
+embedded-hal = "0.2"
+nrf52840-hal = "0.13.0"
 
 [dev-dependencies]
-cortex-m-rt = "0.6.12"
-cortex-m-semihosting = "~0.3"
-panic-semihosting = "~0.5"
-nb = "~0.1"
-panic-rtt-target = { version = "0.1", features = ["cortex-m"] }
-rtt-target = { version = "0.2", features = ["cortex-m"] }
+cortex-m-rt = ">=0.6, <0.8"
+nb = "1.0.0"
+panic-halt = "0.2.0"
+panic-rtt-target = { version = "0.1.2", features = ["cortex-m"] }
+rtt-target = { version = "0.3.1", features = ["cortex-m"] }
 
 [features]
 rt = ["nrf52840-hal/rt"]

--- a/examples/blinky.rs
+++ b/examples/blinky.rs
@@ -4,8 +4,7 @@
 use cortex_m_rt::entry;
 use nb::block;
 
-#[allow(unused_imports)]
-use panic_semihosting;
+use panic_halt as _;
 
 use nrf52840_dk_bsp::{
     hal::{

--- a/examples/blinky_interrupt_rtt.rs
+++ b/examples/blinky_interrupt_rtt.rs
@@ -16,7 +16,7 @@ use panic_rtt_target as _;
 use rtt_target::{rprintln, rtt_init_print};
 
 use bsp::hal;
-use hal::target as pac;
+use hal::pac;
 use nrf52840_dk_bsp as bsp;
 
 use pac::interrupt;

--- a/examples/rtt.rs
+++ b/examples/rtt.rs
@@ -55,7 +55,7 @@ fn main() -> ! {
     let mut log = channels.up.2;
     let mut input = channels.down.0;
     let mut buf = [0u8; 512];
-    if let Some(mut nrf52) = Board::take() {
+    if let Some(nrf52) = Board::take() {
         let mut timer = Timer::new(nrf52.TIMER0);
         let mut count: u8 = 0;
         loop {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,7 +5,6 @@
 #![no_std]
 
 pub use cortex_m;
-pub use cortex_m_rt;
 pub use embedded_hal;
 pub use nrf52840_hal as hal;
 
@@ -18,7 +17,7 @@ pub mod prelude {
 // pub mod debug;
 
 use nrf52840_hal::{
-    gpio::{p0, p1, Floating, Input, Level, Output, Pin, PullUp, PushPull},
+    gpio::{p0, p1, Disconnected, Input, Level, Output, Pin, PullUp, PushPull},
     pac::{self as nrf52, CorePeripherals, Peripherals},
     spim::{self, Frequency, Spim, MODE_0},
     uarte::{self, Baudrate as UartBaudrate, Parity as UartParity, Uarte},
@@ -457,33 +456,33 @@ impl Board {
 /// The nRF52 pins that are available on the nRF52840DK
 #[allow(non_snake_case)]
 pub struct Pins {
-    pub P0_03: p0::P0_03<Input<Floating>>,
-    pub P0_04: p0::P0_04<Input<Floating>>,
-    _RESET: p0::P0_18<Input<Floating>>,
-    pub P0_22: p0::P0_22<Input<Floating>>,
-    pub P0_23: p0::P0_23<Input<Floating>>,
-    pub P0_26: p0::P0_26<Input<Floating>>,
-    pub P0_27: p0::P0_27<Input<Floating>>,
-    pub P0_28: p0::P0_28<Input<Floating>>,
-    pub P0_29: p0::P0_29<Input<Floating>>,
-    pub P0_30: p0::P0_30<Input<Floating>>,
-    pub P0_31: p0::P0_31<Input<Floating>>,
-    pub P1_00: p1::P1_00<Input<Floating>>,
-    pub P1_01: p1::P1_01<Input<Floating>>,
-    pub P1_02: p1::P1_02<Input<Floating>>,
-    pub P1_03: p1::P1_03<Input<Floating>>,
-    pub P1_04: p1::P1_04<Input<Floating>>,
-    pub P1_05: p1::P1_05<Input<Floating>>,
-    pub P1_06: p1::P1_06<Input<Floating>>,
-    pub P1_07: p1::P1_07<Input<Floating>>,
-    pub P1_08: p1::P1_08<Input<Floating>>,
-    pub P1_09: p1::P1_09<Input<Floating>>,
-    pub P1_10: p1::P1_10<Input<Floating>>,
-    pub P1_11: p1::P1_11<Input<Floating>>,
-    pub P1_12: p1::P1_12<Input<Floating>>,
-    pub P1_13: p1::P1_13<Input<Floating>>,
-    pub P1_14: p1::P1_14<Input<Floating>>,
-    pub P1_15: p1::P1_15<Input<Floating>>,
+    pub P0_03: p0::P0_03<Disconnected>,
+    pub P0_04: p0::P0_04<Disconnected>,
+    _RESET: p0::P0_18<Disconnected>,
+    pub P0_22: p0::P0_22<Disconnected>,
+    pub P0_23: p0::P0_23<Disconnected>,
+    pub P0_26: p0::P0_26<Disconnected>,
+    pub P0_27: p0::P0_27<Disconnected>,
+    pub P0_28: p0::P0_28<Disconnected>,
+    pub P0_29: p0::P0_29<Disconnected>,
+    pub P0_30: p0::P0_30<Disconnected>,
+    pub P0_31: p0::P0_31<Disconnected>,
+    pub P1_00: p1::P1_00<Disconnected>,
+    pub P1_01: p1::P1_01<Disconnected>,
+    pub P1_02: p1::P1_02<Disconnected>,
+    pub P1_03: p1::P1_03<Disconnected>,
+    pub P1_04: p1::P1_04<Disconnected>,
+    pub P1_05: p1::P1_05<Disconnected>,
+    pub P1_06: p1::P1_06<Disconnected>,
+    pub P1_07: p1::P1_07<Disconnected>,
+    pub P1_08: p1::P1_08<Disconnected>,
+    pub P1_09: p1::P1_09<Disconnected>,
+    pub P1_10: p1::P1_10<Disconnected>,
+    pub P1_11: p1::P1_11<Disconnected>,
+    pub P1_12: p1::P1_12<Disconnected>,
+    pub P1_13: p1::P1_13<Disconnected>,
+    pub P1_14: p1::P1_14<Disconnected>,
+    pub P1_15: p1::P1_15<Disconnected>,
 }
 
 /// The LEDs on the nRF52840-DK board
@@ -557,8 +556,8 @@ impl Button {
 /// The NFC pins on the nRF52840-DK board
 pub struct NFC {
     /// nRF52840-DK: NFC1, nRF52: P0.09
-    pub nfc_1: p0::P0_09<Input<Floating>>,
+    pub nfc_1: p0::P0_09<Disconnected>,
 
     /// nRF52840-DK: NFC2, nRF52: P0.10
-    pub nfc_2: p0::P0_10<Input<Floating>>,
+    pub nfc_2: p0::P0_10<Disconnected>,
 }


### PR DESCRIPTION
- Update dependencies to latest working.
- Do not depend on cortex-m-rt. The examples do not use the version exposed by this crate and all the other examples I have seen have the app depend on cortex-m-rt directly. I feel like this crate should require the fewest dependencies possible to avoid version mismatches.
- Switch to panic_halt instead of panic_semihosting for examples.