### PR TITLE
Allow Led and Button pins to be released

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,5 +9,6 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Changed
 - Update dependencies
 - Remove cortex-m-rt from main dependencies
+- Allow Led and Button Pins to be released
 
 [Unreleased]: https://github.com/nrf-rs/nrf52840-dk/compare/v0.1.0...HEAD

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -508,6 +508,11 @@ impl Led {
         Led(pin.into_push_pull_output(Level::High))
     }
 
+    /// Release the inner Pin to be used directly
+    pub fn release(self) -> Pin<Output<PushPull>> {
+        self.0
+    }
+
     /// Enable the LED
     pub fn enable(&mut self) {
         self.0.set_low().unwrap()
@@ -540,6 +545,11 @@ pub struct Button(Pin<Input<PullUp>>);
 impl Button {
     fn new<Mode>(pin: Pin<Mode>) -> Self {
         Button(pin.into_pullup_input())
+    }
+
+    /// Release the inner Pin to be used directly
+    pub fn release(self) -> Pin<Input<PullUp>> {
+        self.0
     }
 
     /// Button is pressed


### PR DESCRIPTION
I want to use the BSP but I want access to the underlying Pin instances
so that I can pass them to generic functions.
