### PR TITLE
Prepare release for v0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,15 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+
+(no changes)
+
+## [0.2.0] - 2021-10-01
+
 ### Changed
 - Update dependencies
 - Remove cortex-m-rt from main dependencies
 - Allow Led and Button Pins to be released
 
-[Unreleased]: https://github.com/nrf-rs/nrf52840-dk/compare/v0.1.0...HEAD
+[Unreleased]: https://github.com/nrf-rs/nrf52840-dk/compare/v0.2.0...HEAD
+[0.2.0]: https://github.com/nrf-rs/nrf52840-dk/compare/v0.1.0...v0.2.0

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nrf52840-dk-bsp"
-version = "0.1.0"
+version = "0.2.0"
 description = "BSP for the nRF52840-DK"
 edition = "2018"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,12 +1,16 @@
 [package]
-authors = ["Noah Hüsser <yatekii@yatekii.ch>"]
-categories = ["embedded", "hardware-support", "no-std"]
-description = "BSP for the nRF52840-DK"
-keywords = ["arm", "cortex-m", "nrf52", "hal"]
-license = "MIT OR Apache-2.0"
 name = "nrf52840-dk-bsp"
 version = "0.1.0"
+description = "BSP for the nRF52840-DK"
 edition = "2018"
+
+authors = ["Noah Hüsser <yatekii@yatekii.ch>"]
+categories = ["embedded", "hardware-support", "no-std"]
+keywords = ["arm", "cortex-m", "nrf52", "hal"]
+license = "MIT OR Apache-2.0"
+
+readme = "./README.md"
+repository = "https://github.com/nrf-rs/nrf52840-dk"
 
 [dependencies]
 cortex-m = "0.7"


### PR DESCRIPTION
There have been a couple of changes that I would like to use from the released version of this crate.

## This change includes
- add `repository` and `readme` keys to the `Cargo.toml` to make the crates.io and docs.rs pages a bit nicer
- Bump version in `Cargo.toml` to `0.2.0`.
- Update the CHANGELOG

## New features included in this release
See: https://github.com/nrf-rs/nrf52840-dk/compare/853ff6...HEAD

## Steps to release
I'm not suggesting whoever reads this doesn't know how to publish. Just trying to make the process as painless as possible

```bash
cargo publish
git tag v0.2.0
git push origin v0.2.0
```

It would also be good to add a git tag for the v0.1.0 release. I think it was https://github.com/nrf-rs/nrf52840-dk/commit/853ff6428da43cbc8212ee044161e17818711b6c as crates.io says it was last released on 2020-09-14.

```bash
git tag v0.1.0 853ff64
git push origin v0.1.0
```